### PR TITLE
Add pandas dependency and mount logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ RUN set -ex \
     && pip install apache-airflow[crypto,celery,postgres,hive,jdbc,mysql,ssh${AIRFLOW_DEPS:+,}${AIRFLOW_DEPS}]==${AIRFLOW_VERSION} \
     && pip install 'redis==3.2' \
     && if [ -n "${PYTHON_DEPS}" ]; then pip install ${PYTHON_DEPS}; fi \
+    && pip install 'pandas==1.1.3' \
     && apt-get purge --auto-remove -yqq $buildDeps \
     && apt-get autoremove -yqq --purge \
     && apt-get clean \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
                 max-file: "3"
         volumes:
             - ./dags:/usr/local/airflow/dags
+            - ./logs:/usr/local/airflow/logs
             - ~/docker-certs:/var/docker_certs
             - type: bind
               source: ./config/airflow.cfg


### PR DESCRIPTION
- A specific version of pandas is required to run the merge_queries.py script. Pandas is a binary dependency and so cannot be included in Airflow packaged DAGs.
- Mount the airflow logs server on the host otherwise the logs get lost any time the container is recreated (e.g if environment variables change).